### PR TITLE
Create package.xml

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<package format="1" xmlns="https://wiki.freecad.org/Package_Metadata">
+  <name>Beltrami</name>
+  <description>A workbench for designing turbine blades.</description>
+  <version>1.0.0-alpha</version>
+  <maintainer email="(unknown)">Michel Sabourin (Sabm01)</maintainer>
+  <license file="LICENSE">LGPLv2.1</license>
+  <url type="repository" branch="main">https://github.com/Simturb/Beltrami</url>
+  <icon>Resources/icons/Beltrami_workbench_icon.svg</icon>
+
+  <content>
+    <workbench>
+      <classname>BeltramiWB</classname>
+      <subdirectory>./</subdirectory>
+    </workbench>
+  </content>
+
+</package>

--- a/package.xml
+++ b/package.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no" ?>
 <package format="1" xmlns="https://wiki.freecad.org/Package_Metadata">
   <name>Beltrami</name>
-  <description>A workbench for designing turbine blades.</description>
-  <version>1.0.0-alpha</version>
-  <maintainer email="(unknown)">Michel Sabourin (Sabm01)</maintainer>
+  <description>A workbench for designing turbomachine blades.</description>
+  <version>1.0.6-alpha</version>
+  <maintainer email="simturbweb@gmail.com">Michel Sabourin (Sabm01)</maintainer>
   <license file="LICENSE">LGPLv2.1</license>
   <url type="repository" branch="main">https://github.com/Simturb/Beltrami</url>
   <icon>Resources/icons/Beltrami_workbench_icon.svg</icon>


### PR DESCRIPTION
This PR adds a simple package.xml metadata file to the Beltrami workbench. The format is documented here: https://wiki.freecadweb.org/Package_Metadata . I do not have an email for you, so you'll need to fill that in yourself. I also simply made up a version number: feel free to use something else.