### PR TITLE
Correct name of dependency

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -14,7 +14,7 @@
       <subdirectory>./</subdirectory>
       <tag>curves</tag>
       <tag>nurbs</tag>
-      <depend>Curves workbench</depend>
+      <depend>Curves</depend>
     </workbench>
   </content>
 


### PR DESCRIPTION
The Curves workbench does not include the word "Workbench" in its canonical name.