### PR TITLE
Correct name of Curves dependency

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -18,7 +18,7 @@
       <freecadmin>0.19.3</freecadmin>
       <tag>curves</tag>
       <tag>nurbs</tag>
-      <depend>Curves</depend>
+      <depend>Curves workbench</depend>
     </workbench>
   </content>
 


### PR DESCRIPTION
The canonical name of Curves is actually "Curves workbench", not just "Curves" -- in order for the correct WB dependency to be handled by the Addon Manager, the name must match exactly what Curves calls itself in its package.xml file.